### PR TITLE
fix: Remove job-level condition causing workflow to skip

### DIFF
--- a/.github/workflows/auto-merge-mintmaker.yml
+++ b/.github/workflows/auto-merge-mintmaker.yml
@@ -15,8 +15,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only run for MintMaker bot PRs
-    if: github.event.pull_request.user.login == 'app/red-hat-konflux-kflux-prd-rh03' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository)
+    # Note: Author check is done in "Get PR details" step to avoid job-level condition issues
 
     steps:
       - name: Get PR number


### PR DESCRIPTION
## Summary

The job-level `if` condition was preventing the auto-merge workflow from running even for MintMaker PRs.

## Root Cause

The condition `github.event.pull_request.user.login == 'app/red-hat-konflux-kflux-prd-rh03'` was evaluated at the job level, causing the entire job to be skipped.

## Solution

- Removed job-level `if` condition
- Rely solely on step-level author check in "Get PR details" step
- Workflow now runs for all PRs but exits early if not from MintMaker bot

This is a cleaner approach that avoids condition evaluation issues while still filtering correctly.

## Test plan

- Merge this PR
- Trigger workflow on existing MintMaker PR #10
- Verify auto-merge is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)