### PR TITLE
fix: Handle digest/hash updates in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-mintmaker.yml
+++ b/.github/workflows/auto-merge-mintmaker.yml
@@ -75,11 +75,17 @@ jobs:
           TITLE="${{ steps.pr_details.outputs.title }}"
           echo "Checking PR title: $TITLE"
 
-          # Look for version patterns in the title
-          # Patterns: "v1.2.3 to v2.0.0", "1.2.3 to 2.0.0", "module X to v1.2.3", etc.
+          # Check if this is a digest/hash update (e.g., "update X digest to abc123")
+          # These are safe to auto-merge as they're typically minor updates
+          if echo "$TITLE" | grep -qiE "(digest|commit|hash) to [a-f0-9]+"; then
+            echo "Digest/hash update detected, eligible for auto-merge"
+            echo "is_major=false" >> $GITHUB_OUTPUT
+            echo "reason=digest_update" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
-          # Extract version numbers using regex
-          # Match patterns like: v1.2.3, 1.2.3, or similar
+          # Look for semantic version patterns in the title
+          # Patterns: "v1.2.3 to v2.0.0", "1.2.3 to 2.0.0", "module X to v1.2.3", etc.
           FROM_VERSION=$(echo "$TITLE" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 | sed 's/^v//')
           TO_VERSION=$(echo "$TITLE" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | tail -1 | sed 's/^v//')
 
@@ -87,7 +93,7 @@ jobs:
           echo "To version: $TO_VERSION"
 
           if [ -z "$FROM_VERSION" ] || [ -z "$TO_VERSION" ]; then
-            echo "Could not parse version information, defaulting to manual review"
+            echo "Could not parse semantic version, defaulting to manual review"
             echo "is_major=true" >> $GITHUB_OUTPUT
             echo "reason=version_parse_failed" >> $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
## Summary

Fixes auto-merge workflow to properly handle Git digest/hash-based dependency updates.

## Problem

Many MintMaker PRs use digest-based updates (e.g., `update github.com/google/pprof digest to 5df77e3`) rather than semantic versions. The workflow was failing to parse these and defaulting to "manual review required".

## Solution

- Added regex detection for digest/hash updates: `(digest|commit|hash) to [a-f0-9]+`
- Treat digest updates as safe for auto-merge (similar to minor/patch updates)
- Maintain semantic version parsing and major version detection for version-based updates

## Impact

This will allow the auto-merge workflow to handle both types of dependency updates:
- ✅ Digest updates: `update X digest to abc123`
- ✅ Semantic version updates: `update X to v1.2.3`
- ❌ Major version updates: `update X to v2.0.0` (still requires manual review)

## Test plan

- Wait for CI to pass
- Merge and test on PR #10 (digest update)
- Verify auto-merge is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)