### PR TITLE
refactor: Remove automatic label adding from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-mintmaker.yml
+++ b/.github/workflows/auto-merge-mintmaker.yml
@@ -60,14 +60,6 @@ jobs:
             echo "has_no_automerge=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Add labels to PR
-        if: steps.pr_details.outputs.is_mintmaker == 'true' && steps.pr_details.outputs.state == 'OPEN'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Add dependencies and mintmaker labels if not already present
-          gh pr edit ${{ steps.pr.outputs.number }} --repo ${{ github.repository }} --add-label "dependencies,mintmaker" || true
-
       - name: Detect version change type
         id: version_check
         if: steps.pr_details.outputs.is_mintmaker == 'true' && steps.pr_details.outputs.has_no_automerge == 'false' && steps.pr_details.outputs.state == 'OPEN'


### PR DESCRIPTION
## Summary

Removes the automatic label-adding logic from the auto-merge workflow.

## Rationale

The workflow already filters by bot username (`app/red-hat-konflux-kflux-prd-rh03`), so adding `dependencies` and `mintmaker` labels is unnecessary and purely cosmetic.

## What's Removed

- "Add labels to PR" step that added `dependencies` and `mintmaker` labels

## What's Preserved

- ✅ Filtering by bot username
- ✅ `no-automerge` label check (opt-out mechanism)
- ✅ All auto-merge logic
- ✅ Trigger on `labeled`/`unlabeled` (needed for `no-automerge` label)

## Impact

- New MintMaker PRs will no longer get labels automatically
- Existing labels on PRs are unaffected
- Workflow functionality remains identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)